### PR TITLE
Endpoint refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ RUN apt update
 
 RUN apt -y install gcc
 
-RUN python -m pip install --upgrade pip
-
 RUN pip3 install -r requirements.txt
 
 #TODO expose ports based on conf.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt update
 
 RUN apt -y install gcc
 
+RUN python -m pip install --upgrade pip
+
 RUN pip3 install -r requirements.txt
 
 #TODO expose ports based on conf.cfg

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ You can register/login in the app using our internal protocol, or OAuth2 and goo
             "image": str,
             "name": str,
             "region": str
+            "is_stamped": bool
         },
     ]
     }

--- a/README.md
+++ b/README.md
@@ -266,19 +266,17 @@ You can register/login in the app using our internal protocol, or OAuth2 and goo
   - 422 - id argument missing
   - 404 - User doesn't exist
 
-- `/api/get_stamp_token` [GET]
+- `/api/get_id_token` [GET]
 
-  For EMPLOYEES to get a stamp token, that WILL be scanned from the users
+  For usersS to get a stamp token, that WILL be scanned from the employees
 
   the request requires header:
   `Authorization` : valid Auth token
 
-  the request requires the user to be an employee
-
-  if Auth is valid and user is employee:
+  if Auth is valid:
   ```
   {
-    "stamp_token" : str
+    "id_token" : str
   }
   ```
 
@@ -287,15 +285,15 @@ You can register/login in the app using our internal protocol, or OAuth2 and goo
   - 401: Not employee
   - 400: Employee without assigned place
 
-- `/api/receive_stamp` [POST]
+- `/api/make_stamp` [POST]
   
-  For USERS to recieve a stamp, that IS scanned from an employee
+  For EMPLOYEES to make a stamp, that IS scanned from an employee
 
   the request requires header:
   `Authorization` : valid auth token
 
   the request requires the args as form-data:
-  `stamp_token` : str
+  `id_token` : str
 
   if the user is authorized and token is valid:
   ```

--- a/README.md
+++ b/README.md
@@ -268,12 +268,12 @@ You can register/login in the app using our internal protocol, or OAuth2 and goo
 
 - `/api/get_id_token` [GET]
 
-  For usersS to get a stamp token, that WILL be scanned from the employees
+  For users to get a stamp token, that will be scanned from the employees
 
   the request requires header:
   `Authorization` : valid Auth token
 
-  if Auth is valid:
+  if Auth is valid, returns:
   ```
   {
     "id_token" : str
@@ -282,12 +282,10 @@ You can register/login in the app using our internal protocol, or OAuth2 and goo
 
   excepts:
   - 401: Not logged in
-  - 401: Not employee
-  - 400: Employee without assigned place
 
 - `/api/make_stamp` [POST]
   
-  For EMPLOYEES to make a stamp, that IS scanned from an employee
+  For EMPLOYEES to make a stamp
 
   the request requires header:
   `Authorization` : valid auth token
@@ -295,7 +293,7 @@ You can register/login in the app using our internal protocol, or OAuth2 and goo
   the request requires the args as form-data:
   `id_token` : str
 
-  if the user is authorized and token is valid:
+  if the user is employee, authorized and token is valid:
   ```
   {
     "message" : str
@@ -306,7 +304,6 @@ You can register/login in the app using our internal protocol, or OAuth2 and goo
   - 401: not authorized
   - 400: expired/invalid token
   - 400: employee trying to give himself a stamp
-  - 400: already have this stamp
 
 
 - `/imageserver/tourist_sites` [GET]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ google_auth_oauthlib~=0.5.0
 google_api_python_client~=2.39.0
 Quart-CORS~=0.5.0
 hypercorn~=0.13.2
+Jinja2 == 3.0.3

--- a/src/app.py
+++ b/src/app.py
@@ -548,7 +548,7 @@ async def profile_pictures():
         )
 
         if path.isfile(file_path):
-            return await send_file(file_path, mimetype='image/gif', as_attachment=True)
+            return await send_file(file_path, mimetype='image/gif')
         else:
             return {"error": "Picture not found", }, 404
 

--- a/src/app.py
+++ b/src/app.py
@@ -38,7 +38,7 @@ application = Quart(__name__, )
 application = cors(
     application,
     allow_origin="*",
-    allow_headers=['Authorization', 'Content-type', ],
+    allow_headers=['Authorization', 'Content-Type', ],
     allow_methods=['GET', 'POST', ],
 )
 
@@ -178,13 +178,13 @@ async def id_token() -> Tuple[Dict[str, str], int]:
         }, 200
 
 
-@application.route('/api/receive_stamp', methods=['POST', ], )
+@application.route('/api/make_stamp', methods=['POST', ], )
 async def receive_stamp() -> Tuple[Dict[str, str], int]:
     """
     Endpoint for receiving a stamp from a scanned token.
 
     args:
-        'stamp_token' : str -> scanned token
+        'id_token' : str -> scanned token
 
     returns:
         {"message" : str} on success
@@ -198,7 +198,7 @@ async def receive_stamp() -> Tuple[Dict[str, str], int]:
     async with async_session() as session:
 
         # Make a stamp object
-        stamp_token: str = (await request.form).get('stamp_token')
+        stamp_token: str = (await request.form).get('id_token')
         logger.debug(f"User (id:{g.authenticated_user}) requested a stamp")
 
         try:
@@ -206,7 +206,7 @@ async def receive_stamp() -> Tuple[Dict[str, str], int]:
                 session, stamp_token, g.authenticated_user)
             logger.debug("Stamp successfully made!")
         except InvalidStampToken:
-            return {'error': "The stamp token has expired or isn't valid!"}, 400
+            return {'error': "The stamp token has expired or isn't valid or user isn't employee!"}, 400
 
         if stamp.visitor_id == stamp.employee_id:
             logger.warning(

--- a/src/app.py
+++ b/src/app.py
@@ -30,6 +30,8 @@ UNAUTHENTICATED_URLS: List[str] = [
     '/api/login',
     '/api/registration',
     '/api/oauth2/google',
+    # '/imageserver/tourist_sites',
+    # '/imageserver/profile_pictures'
 ]
 
 application = Quart(__name__, )
@@ -149,11 +151,11 @@ async def get_site_info():
 # Stamping endpoints
 
 
-@application.route('/api/get_stamp_token', methods=['GET', ], )
-async def stamp_token() -> Tuple[Dict[str, str], int]:
+@application.route('/api/get_id_token', methods=['GET', ], )
+async def id_token() -> Tuple[Dict[str, str], int]:
     """
-    Parameter for getting a token to be scanned (via QR)
-    Requires user to be an employee. Token has a 30sec validity.
+    Parameter for getting an identification token to be scanned (via QR)
+    Token has a 30sec validity.
 
     returns:
         {"stamp_token" : str}
@@ -167,29 +169,11 @@ async def stamp_token() -> Tuple[Dict[str, str], int]:
     async with async_session() as session:
 
         logger.debug(
-            f"user with id {g.authenticated_user} requested a stamp token")
-
-        # Get employee info
-        employee: Optional[Dict[str, Any]] = await Employees.by_id(session, g.authenticated_user)
-
-        if employee is None:
-            logger.warning(
-                f"Non employee (id:{g.authenticated_user}) requested stamp token!")
-            return {
-                'error': 'Only allowed for employees!',
-            }, 401
-
-        if employee.get('place_id') is None:
-            logger.warning(
-                f"Employee with id {g.authenticated_user} doesn't have an allocated place!")
-            return {
-                'error': 'You dont have an assigned place! Please contact an admin',
-            }, 400
+            f"user with id {g.authenticated_user} requested a ID token")
 
         return {
-            'stamp_token': generate_stamp_token(
+            'id_token': generate_stamp_token(
                 g.authenticated_user,
-                employee['place_id'],
             ),
         }, 200
 
@@ -216,10 +200,10 @@ async def receive_stamp() -> Tuple[Dict[str, str], int]:
         # Make a stamp object
         stamp_token: str = (await request.form).get('stamp_token')
         logger.debug(f"User (id:{g.authenticated_user}) requested a stamp")
-        logger.debug(f"stamp_token type : {type(stamp_token)}")
 
         try:
-            stamp: Stamp = make_stamp(stamp_token, g.authenticated_user)
+            stamp: Stamp = await make_stamp(
+                session, stamp_token, g.authenticated_user)
             logger.debug("Stamp successfully made!")
         except InvalidStampToken:
             return {'error': "The stamp token has expired or isn't valid!"}, 400
@@ -564,7 +548,7 @@ async def profile_pictures():
         )
 
         if path.isfile(file_path):
-            return await send_file(file_path, mimetype='image/gif', )
+            return await send_file(file_path, mimetype='image/gif', as_attachment=True)
         else:
             return {"error": "Picture not found", }, 404
 

--- a/src/app.py
+++ b/src/app.py
@@ -90,6 +90,7 @@ async def get_all_sites():
             'image':str,
             'name':str,
             'region':str
+            'is_stamped':bool
         },
     ]
 

--- a/src/auth.py
+++ b/src/auth.py
@@ -31,7 +31,7 @@ def verify_password(password: str, password_hash: bytes) -> bool:
 
 def generate_token(data) -> str:
     return __enc_box.encrypt(
-        f"{data}\n{(datetime.utcnow() + timedelta(hours=3)).isoformat()}"
+        f"{data}\n{(datetime.utcnow() + timedelta(days=7)).isoformat()}"
         f"".encode('utf-8')
     ).hex()
 

--- a/src/database/model/places.py
+++ b/src/database/model/places.py
@@ -8,7 +8,6 @@ from .regions import Regions
 
 
 class Places(ORMBase):
-    region_id = id_ref_column('region_id', Regions.id, )
 
     city_id = id_ref_column('city_id', Cities.id, )
 

--- a/src/response_formaters.py
+++ b/src/response_formaters.py
@@ -45,17 +45,24 @@ async def get_tourist_sites(session: AsyncSession, site_type: AllSitesFilter, vi
             if site.get('id') in stamp_places_id:
                 continue
 
-        # FIXME image will fail if there are no images to the place
+        # Fetch image id
+        image_id = (
+            await Images.all_by_place(
+                session, site.get('id'),
+            )
+        )
+
+        # Get first element of array only after we know we have an image
+        if image_id is not None:
+            image_id = image_id[0]
+
         current_site = {
             'id': site['id'],
-            'image': (
-                await Images.all_by_place(
-                    session, site.get('id'),
-                )
-            )[0],
+            'image': image_id,
             'region': site['region_name'],
             'city': site['city_name'],
             'name': site['name'],
+            'is_stamped': bool(site.get('id') in stamp_places_id)
         }
 
         # get only 1 image for visualisation of the card

--- a/src/stamps.py
+++ b/src/stamps.py
@@ -61,17 +61,18 @@ async def make_stamp(session: AsyncSession, token: str, employee_id: int) -> Sta
         token: List[str] = __dec_box.decrypt(bytes.fromhex(token)) \
             .decode('utf-8').split('\n')
 
-        logger.debug("Token decoded : {token}")
-        logger.debug(f"time now :  {datetime.utcnow()}")
-        logger.debug(f"token time: {datetime.fromisoformat(token[1])}")
+        if len(token == 2):
+            logger.debug("Token decoded : {token}")
+            logger.debug(f"time now :  {datetime.utcnow()}")
+            logger.debug(f"token time: {datetime.fromisoformat(token[1])}")
 
-        # Check if we have the 2 fields, if token hasn't expired, make a stamp
-        if len(token) == 2 and datetime.utcnow() < datetime.fromisoformat(token[1]):
-            logger.debug("Stamp is valid, return stamp...")
-            return Stamp(employee_id, place_id, int(token[0]))
-        else:
-            logger.debug("Stamp invalid, raise exception")
-            raise InvalidStampToken()
+            # Check if we have the 2 fields, if token hasn't expired, make a stamp
+            if datetime.utcnow() < datetime.fromisoformat(token[1]):
+                logger.debug("Stamp is valid, return stamp...")
+                return Stamp(employee_id, place_id, int(token[0]))
+            else:
+                logger.debug("Stamp invalid, raise exception")
+                raise InvalidStampToken()
     except (ValueError, TypeError, CryptoError) as ex:
         logger.debug(ex)
         logger.debug("Decrypting error...")

--- a/src/stamps.py
+++ b/src/stamps.py
@@ -48,10 +48,12 @@ async def make_stamp(session: AsyncSession, token: str, employee_id: int) -> Sta
     '''
     employee = await Employees.by_id(session, employee_id)
     if employee is None:
+        logger.debug("Employee doesn't exist!")
         raise InvalidStampToken()
 
     place_id = employee.get("place_id")
     if place_id is None:
+        logger.debug("Employee doesn't have an assigned place!")
         raise InvalidStampToken()
 
     try:


### PR DESCRIPTION
- login token validity now 7 days
- Refactor stamps functionality
- rename get_stamp_token to get_id_token
- token now only takes user id
- receive_stamp now called make_stamp
- make stamp only accessible by employees